### PR TITLE
Change string to text column to allow long URL

### DIFF
--- a/src/Migrations/2019_07_15_000000_create_firewall_logs_table.php
+++ b/src/Migrations/2019_07_15_000000_create_firewall_logs_table.php
@@ -18,12 +18,12 @@ class CreateFirewallLogsTable extends Migration
             $table->string('level')->default('medium');
             $table->string('middleware');
             $table->integer('user_id')->nullable();
-            $table->string('url')->nullable();
+            $table->text('url')->nullable();
             $table->string('referrer')->nullable();
             $table->text('request')->nullable();
             $table->timestamps();
             $table->softDeletes();
-            
+
             $table->index('ip');
         });
     }


### PR DESCRIPTION
Hi,
To allow long URL in `firewall_logs` table, I change column type to `text` (from `string`).   

Max URL length : 2,048 characters for IE (Browser with smaller URL length)  

Source : https://support.microsoft.com/en-us/topic/maximum-url-length-is-2-083-characters-in-internet-explorer-174e7c8a-6666-f4e0-6fd6-908b53c12246