### PR TITLE
prevent ip block but add message to request. This is especially usefu…

### DIFF
--- a/src/Abstracts/Middleware.php
+++ b/src/Abstracts/Middleware.php
@@ -30,10 +30,34 @@ abstract class Middleware
         }
 
         if ($this->check($this->getPatterns())) {
+
+            if ($this->preventIpBlock()) {
+                $request->request->add(['prevented_ip_block' => true]);
+                return $next($request);
+            }
+
             return $this->respond(config('firewall.responses.block'));
         }
 
         return $next($request);
+    }
+
+    private function preventIpBlock()
+    {
+        if (!config('firewall.prevent_block_ips')) {
+            return false;
+        }
+
+        if (config('firewall.prevent_block_ips') === '*') {
+            return true;
+        }
+
+        $preventBlockIps = explode(',', config('firewall.prevent_block_ips'));
+        if (in_array(request()->ip(), $preventBlockIps, true)) {
+            return true;
+        }
+
+        return false;
     }
 
     public function skip($request)

--- a/src/Config/firewall.php
+++ b/src/Config/firewall.php
@@ -6,6 +6,18 @@ return [
 
     'whitelist' => [env('FIREWALL_WHITELIST', '')],
 
+    # --------- PREVENT IP BLOCK ------------------
+    # The following IP's are never blocked but they will still pass through all checks
+    # Whitelising skips checks, prevent_ip_block will still register the ip as blocked,
+    # but will not block the actual request
+    # instead it will add 'prevented_ip_block' = true to the request
+    # so you can show the user that their IP would have been blocked
+    # -------------------------------------------------
+    # Whitelisted IP    Reason/Location
+    # *                 : any location
+    # 111.112.112.112   : some remote host
+    'prevent_block_ips' => [env('FIREWALL_PREVENT_BLOCK_IPS', null)],
+
     'models' => [
         'user' => '\App\Models\User',
         // 'log' => '\App\Models\YourLogModel',


### PR DESCRIPTION
prevent ip block but add message to request. This is especially usefull when you want to keep your firewall intact, but still allow certain ips to pass. Just whitelisting bypasses the entire firewall, prevent_ip_block keeps your firewall and logging all the same but the ip passes and a flag is added to the request that normally the ip would have been blocked

Also usefull if you allow certain ips to pentest your system, and allow them to see that normally the firewall would have been kicked in and banned the ip