### PR TITLE
Prevent error on empty query value

### DIFF
--- a/src/Abstracts/Middleware.php
+++ b/src/Abstracts/Middleware.php
@@ -109,6 +109,10 @@ abstract class Middleware
         }
 
         foreach ($input as $key => $value) {
+            if (empty($value)) {
+                continue;
+            }
+
             if (is_array($value)) {
                 if (!$result = $this->match($pattern, $value)) {
                     continue;

--- a/src/Middleware/Php.php
+++ b/src/Middleware/Php.php
@@ -19,6 +19,10 @@ class Php extends Middleware
         }
 
         foreach ($input as $key => $value) {
+            if (empty($value)) {
+                continue;
+            }
+
             if (is_array($value)) {
                 if (!$result = $this->match($pattern, $value)) {
                     continue;

--- a/src/Middleware/Rfi.php
+++ b/src/Middleware/Rfi.php
@@ -23,6 +23,10 @@ class Rfi extends Middleware
         }
 
         foreach ($input as $key => $value) {
+            if (empty($value)) {
+                continue;
+            }
+
             if (is_array($value)) {
                 if (!$result = $this->match($pattern, $value)) {
                     continue;
@@ -48,7 +52,7 @@ class Rfi extends Middleware
 
         return $result;
     }
-    
+
     protected function applyExceptions($string)
     {
         $exceptions = config('firewall.middleware.' . $this->middleware . '.exceptions');
@@ -62,7 +66,7 @@ class Rfi extends Middleware
 
         return str_replace($exceptions, '', $string);
     }
-    
+
     protected function checkContent($value)
     {
         $contents = @file_get_contents($value);
@@ -70,7 +74,7 @@ class Rfi extends Middleware
         if (!empty($contents)) {
             return (strstr($contents, '<?php') !== false);
         }
-        
+
         return false;
     }
 }


### PR DESCRIPTION
# Bug
On query param without value, some PHP deprecated warnings appear.
`documents?query=` 

# Example of log warning:

```
[08:41:58] LOG.warning: preg_match(): Passing null to parameter #2 ($subject) of type string is deprecated in /Users/thomascombe/PhpstormProjects/intranet-rondot-group/vendor/akaunting/laravel-firewall/src/Abstracts/Middleware.php on line 126
````