### PR TITLE
limit request log size

### DIFF
--- a/src/Config/firewall.php
+++ b/src/Config/firewall.php
@@ -401,4 +401,9 @@ return [
 
     ],
 
+    // Maximum number of characters to log. This will prevent database errors when the request is too large (ie of rfi)
+    'logging' => [
+        'max_request_size' => 1024,
+    ]
+
 ];

--- a/src/Models/Log.php
+++ b/src/Models/Log.php
@@ -19,4 +19,13 @@ class Log extends Model
     {
         return $this->belongsTo(config('firewall.models.user'));
     }
+
+    protected static function booted()
+    {
+        parent::boot();
+
+        static::saving(function ($model) {
+            $model->request = substr($model->request, 0, config('firewall.logging.max_request_size'));
+        });
+    }
 }


### PR DESCRIPTION
When the request is very long (in my case it was a base64 encoded screenshot that triggered the rfi) then the database layer would break as the request size was too long to insert in the database.

With this MR the request size is reduced to the setting in the config