### PR TITLE
Patched service provider to work with Laravel 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     ],
     "require": {
         "php": ">=7.3",
-        "laravel/framework": ">=5.5",
+        "laravel/framework": "5.5 - 7",
         "guzzlehttp/guzzle": ">=6.0",
         "jenssegers/agent": "2.6.*"
     },

--- a/src/Provider.php
+++ b/src/Provider.php
@@ -57,7 +57,7 @@ class Provider extends ServiceProvider
      */
     public function registerMiddleware($router)
     {
-        $router->middlewareGroup('firewall.all', config('firewall.all_middleware'));
+        $router->middlewareGroup('firewall.all', config('firewall.all_middleware') ?? []);
         $router->aliasMiddleware('firewall.agent', 'Akaunting\Firewall\Middleware\Agent');
         $router->aliasMiddleware('firewall.bot', 'Akaunting\Firewall\Middleware\Bot');
         $router->aliasMiddleware('firewall.ip', 'Akaunting\Firewall\Middleware\Ip');


### PR DESCRIPTION
Patched service provider to work with Laravel 7, which requires an array as second parameter to middlewareGroup(), when it is null before config is cached.