### PR TITLE
limit referrer max size

### DIFF
--- a/src/Traits/Helper.php
+++ b/src/Traits/Helper.php
@@ -96,7 +96,7 @@ trait Helper
             'middleware' => $middleware,
             'user_id' => $user_id,
             'url' => $this->request->fullUrl(),
-            'referrer' => $this->request->server('HTTP_REFERER') ?: 'NULL',
+            'referrer' => substr($this->request->server('HTTP_REFERER'), 0, 191) ?: 'NULL',
             'request' => substr($input, 0, config('firewall.log.max_request_size')),
         ]);
     }


### PR DESCRIPTION
I saw many of the following errors in the logs due to too long `referrer`.
```production.ERROR: SQLSTATE[22001]: String data, right truncated: 1406 Data too long for column 'referrer' at row 1 (SQL: insert into `firewall_logs` (`ip`, `level`, `middleware`, `user_id`, `url`, `referrer`, `request`, `updated_at`, `created_at`)```