### PR TITLE
Allow Multiple Whitelist IPs

### DIFF
--- a/src/Config/firewall.php
+++ b/src/Config/firewall.php
@@ -4,7 +4,7 @@ return [
 
     'enabled' => env('FIREWALL_ENABLED', true),
 
-    'whitelist' => [env('FIREWALL_WHITELIST', '')],
+    'whitelist' => explode(',',env('FIREWALL_WHITELIST', '')),
 
     'models' => [
         'user' => '\App\Models\User',

--- a/tests/Feature/WhitelistTest.php
+++ b/tests/Feature/WhitelistTest.php
@@ -15,6 +15,13 @@ class WhitelistTest extends TestCase
         $this->assertEquals('next', (new Whitelist())->handle($this->app->request, $this->getNextClosure()));
     }
 
+    public function testShouldAllowMultiple()
+    {
+        config(['firewall.whitelist' => ['127.0.0.0/24:0.0.0.0']]);
+
+        $this->assertEquals('next', (new Whitelist())->handle($this->app->request, $this->getNextClosure()));
+    }
+
     public function testShouldBlock()
     {
         $this->assertEquals('403', (new Whitelist())->handle($this->app->request, $this->getNextClosure())->getStatusCode());


### PR DESCRIPTION
Fixes #57 Allow multiple whitelist IPs to be able to be defined within the Whitelist IP environment variable.