### PR TITLE
[FEATURE REQUEST] implementig support for custom notification channels

### DIFF
--- a/src/Config/firewall.php
+++ b/src/Config/firewall.php
@@ -51,7 +51,22 @@ return [
             'channel' => env('FIREWALL_SLACK_CHANNEL', null), // set null to use the default channel of webhook
             'queue' => env('FIREWALL_SLACK_QUEUE', 'default'),
         ],
+        
+        /*
+        |--------------------------------------------------------------------------
+        | CUSTOM CHANNELS
+        |--------------------------------------------------------------------------
+        |
+        | your applcation notification channels, as documented 
+        | in https://laravel.com/docs/10.x/notifications#custom-channels
+        |
+        */
 
+        // 'custom' => [
+        //     'enabled' => true,
+        //     'channel' => App\Notifications\CustomChannel::class,
+        //     'queue' => 'customqueue',
+        // ],
     ],
 
     'all_middleware' => [

--- a/src/Notifications/AttackDetected.php
+++ b/src/Notifications/AttackDetected.php
@@ -13,6 +13,14 @@ class AttackDetected extends Notification implements ShouldQueue
     use Queueable;
 
     /**
+     * Channels with built-in support, which don't require a custom handler.
+     */
+    const DEFAULT_CHANNELS = [
+        'mail',
+        'slack'
+    ];
+
+    /**
      * The log model.
      *
      * @var object
@@ -50,6 +58,8 @@ class AttackDetected extends Notification implements ShouldQueue
                 continue;
             }
 
+            $channel = in_array($channel, self::DEFAULT_CHANNELS) ? $channel : $settings['channel'];
+
             $channels[] = $channel;
         }
 
@@ -63,7 +73,15 @@ class AttackDetected extends Notification implements ShouldQueue
 
     public function viaQueues(): array
     {
-        return array_map(fn ($channel) => $channel['queue'] ?? 'default', $this->notifications);
+        $channels = [];
+
+        foreach ($this->notifications as $channel => $settings) {
+
+            $key = in_array($channel, self::DEFAULT_CHANNELS) ? $channel : $settings['channel'];
+            
+            $channels[$key] = $settings['queue'] ?? 'default';
+        }
+        return $channels;
     }
 
     /**


### PR DESCRIPTION
Kinda built-in support for custom notifications. Had to change viaQueues as well to make it compatible with this commit.
Sample Usage:
`<?php

class customFWChannel {
    public function send($notifiable, \Akaunting\Firewall\Notifications\AttackDetected $a) {
        \Log::debug('sending to a custom channel');
    }
}

config()->set('firewall.notifications.custom', [
    'enabled' => true,
    'channel' => customFWChannel::class,
    'queue' => 'customqueue'
]);

$fakeAttack = (object) [
  "ip" => "192.168.240.1",
  "level" => "medium",
  "middleware" => "url",
  "user_id" => 0,
  "url" => "http://localhost/admin",
  "referrer" => "NULL",
  "request" => "",
  "updated_at" => "2023-10-02T08:53:24.000000Z",
  "created_at" => "2023-10-02T08:53:24.000000Z",
  "id" => 61
];
(new \Akaunting\Firewall\Notifications\Notifiable)->notify(
    new \Akaunting\Firewall\Notifications\AttackDetected($fakeAttack)
);`