### PR TITLE
Update BlockIp.php

### DIFF
--- a/src/Listeners/BlockIp.php
+++ b/src/Listeners/BlockIp.php
@@ -27,7 +27,7 @@ class BlockIp
                     ->whereBetween('created_at', [$start, $end])
                     ->count();
 
-        if ($count != config('firewall.middleware.' . $event->log->middleware . '.auto_block.attempts')) {
+        if ($count < config('firewall.middleware.' . $event->log->middleware . '.auto_block.attempts')) {
             return;
         }
 


### PR DESCRIPTION
The check has to be "less than" comparison instead of "not equals".

I was testing the firewall to see if it blocks:

- first the `attempts` was `10`
- then I reloaded the page with a "blockable" content **_6 times_**
- then I reduced the `attempts` to `5`

This caused the firewall to **NOT** block the IP.

Here is a before after comparison for the example above:


```php
// before
if ($count != config('firewall.middleware.' . $event->log->middleware . '.auto_block.attempts')) {
    return;
}
// values
if (6 != 5) {
    return; // doesn't block the IP
}
```

```php
// after
if ($count < config('firewall.middleware.' . $event->log->middleware . '.auto_block.attempts')) {
    return;
}
// values
if (6 < 5) {
    return; // blocks the IP
}
```